### PR TITLE
ci(main): Don't remove version v prefix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
           echo $TAG_NAME
           gh release create "$TAG_NAME" \
             --title "$TAG_NAME" \
-            --notes "See: https://github.com/rvben/rumdl/releases/tag/${TAG_NAME/v}" \
+            --notes "See: https://github.com/rvben/rumdl/releases/tag/$TAG_NAME" \
             --latest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 


### PR DESCRIPTION
The upstream tag name contains v as well.

[rumdl-pre-commit release](https://github.com/rvben/rumdl-pre-commit/releases/tag/v0.0.188) says `See: https://github.com/rvben/rumdl/releases/tag/0.0.188` but rumdl release tag is `https://github.com/rvben/rumdl/releases/tag/v0.0.188`.